### PR TITLE
Improves initial onboarding experience

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# Common Settings - GA
-REACT_APP_googleTrackingId = ""

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_modules/
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 1. You must have [node.js](https://nodejs.org/en) installed.
 2. Once you download the repository, you need install the dependencies with the command: `npm ci`.
-3. Choose the right configuration for your agency, file: **_config.ts_**
+3. Choose the right configuration for your agency: copy `env.example` to `.env` and edit the `.env` file to set an app name, API key, and API server URL. More configuration options are available in `config.ts`.
 4. Then you can run: `npm start` or do build: `npm run build`.
 5. Finally, there's deployment. Follow this [instruction](https://create-react-app.dev/docs/deployment)
 

--- a/example.env
+++ b/example.env
@@ -1,0 +1,8 @@
+# Common Settings - GA
+REACT_APP_googleTrackingId = ""
+
+# API Server
+REACT_APP_API_BASE_URL = "https://api.pugetsound.onebusaway.org/"
+REACT_APP_API_KEY = "test"
+REACT_APP_APP_NAME = "OneBusAway React App"
+REACT_APP_SIRI_API_KEY = ""

--- a/src/components/DeparturesBoard/DepartureBoard.tsx
+++ b/src/components/DeparturesBoard/DepartureBoard.tsx
@@ -7,7 +7,7 @@ import scrollIntoView from "scroll-into-view-if-needed";
 import { Table } from "react-bootstrap";
 import { shallowEqual } from "react-redux";
 
-import { api_key2, fetchIntervalStop, key_siri, prefixURL } from "../../config";
+import { apiKey, fetchIntervalStop, siriApiKey, apiBaseURL } from "../../config";
 import { useAppSelector } from "../../redux/hooks";
 import { cutAgencyName, timeConverterFromNow } from "../../utils/helpers";
 import { logo } from "../../config";
@@ -211,7 +211,7 @@ const DepartureBoard = (): JSX.Element => {
       const controller = new AbortController();
 
       const stopInfoURLs = stopIds.map((stopInfoId: string) => {
-        return `${prefixURL}/api/where/stop/${stopInfoId}.json?key=${api_key2}`;
+        return `${apiBaseURL}/api/where/stop/${stopInfoId}.json?key=${apiKey}`;
       });
       // console.log({ stopInfoURLs });
 
@@ -264,7 +264,7 @@ const DepartureBoard = (): JSX.Element => {
       const getDepartureInfo = () => {
         axios
           .get(
-            `${prefixURL}/siri/stop-monitoring?key=${key_siri}&_=${now}&OperatorRef=${agencyId}&MonitoringRef=${stopIds[index]}&StopMonitoringDetailLevel=normal&MinimumStopVisitsPerLine=3&type=json`
+            `${apiBaseURL}/siri/stop-monitoring?key=${siriApiKey}&_=${now}&OperatorRef=${agencyId}&MonitoringRef=${stopIds[index]}&StopMonitoringDetailLevel=normal&MinimumStopVisitsPerLine=3&type=json`
           )
           .then(({ data }) => {
             const dataToState = data?.Siri?.ServiceDelivery?.StopMonitoringDelivery[0]?.MonitoredStopVisit;

--- a/src/components/ModalBottom/TimeTableChangeDate.tsx
+++ b/src/components/ModalBottom/TimeTableChangeDate.tsx
@@ -11,7 +11,7 @@ import { dispatchModalInfoBottomIsOpen, selectStop } from "../../redux/actions";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import busTimetable from "../../assets/Icons/busTimetable.svg";
 import { cutAgencyName, dateToString, setNewDate, timeConverter, truncateString } from "../../utils/helpers";
-import { api_key, prefixURL, routeListButtonWidth } from "../../config";
+import { apiKey, apiBaseURL, routeListButtonWidth } from "../../config";
 import TimeTablePart from "./TimeTablePart";
 
 const DatePickerContainer = styled.div`
@@ -156,7 +156,7 @@ const TimeTableChangeDate = (): JSX.Element => {
     // console.log({ dateToSend });
     // console.log({ id });
     axios
-      .get(`${prefixURL}/api/where/schedule-for-stop/${stop_Id}.json?date=${dateToSend}&key=${api_key}`)
+      .get(`${apiBaseURL}/api/where/schedule-for-stop/${stop_Id}.json?date=${dateToSend}&key=${apiKey}`)
       .then(({ data }) => {
         const busStopDataFromApi = data?.data?.entry?.stopRouteSchedules;
         // console.log("busStopDataFromApi:", busStopDataFromApi);

--- a/src/components/ModalBottom/VehicleInfo.tsx
+++ b/src/components/ModalBottom/VehicleInfo.tsx
@@ -8,9 +8,9 @@ import { shallowEqual } from "react-redux";
 
 import {
   fetchInterval,
-  key_siri,
+  siriApiKey,
   maximumNumberOfCallsOnwards,
-  prefixURL,
+  apiBaseURL,
   routeListButtonWidth,
   showDevInfo,
 } from "../../config";
@@ -114,7 +114,7 @@ const VehicleInfo = (): JSX.Element => {
       const getBusInfo = () => {
         axios
           .get(
-            `${prefixURL}/siri/vehicle-monitoring?key=${key_siri}&OperatorRef=${agencyId}&VehicleRef=${vehicleRefShort}&MaximumNumberOfCallsOnwards=${maximumNumberOfCallsOnwards}&VehicleMonitoringDetailLevel=calls&TripId=${blockRef}&type=json`
+            `${apiBaseURL}/siri/vehicle-monitoring?key=${siriApiKey}&OperatorRef=${agencyId}&VehicleRef=${vehicleRefShort}&MaximumNumberOfCallsOnwards=${maximumNumberOfCallsOnwards}&VehicleMonitoringDetailLevel=calls&TripId=${blockRef}&type=json`
           )
           .then(({ data }) => {
             // console.log("data:", data);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,17 +1,20 @@
-//* Agency Config
 import logoOBA from "./assets/Logo/logoOBA.png"; //* customize here
+
+//* You can configure these settings with a .env file
+// The REACT_APP prefix is necessary as explained here: https://stackoverflow.com/a/56668716/136839
+export const apiBaseURL = process.env.REACT_APP_API_BASE_URL ?? ""; //! Add api here!
+export const apiKey = process.env.REACT_APP_API_KEY ?? ""; //! Add key here!
+export const siriApiKey = process.env.REACT_APP_SIRI_API_KEY ?? ""; //! Add key here!
+export const appName = process.env.REACT_APP_APP_NAME ?? "OneBusAway React WebApp"; //* customize here
+
+//* UI Config
 export const logo = logoOBA;
 export const fetchOnStart = true;
 export const listPositionForAgency = 0; //* y
 export const minLinesAtStop = 4; //* customize here
 export const reducePolylinesPoints = 3; //* customize here
 export const showChangeLanguage = true; //* customize here
-export const prefixURL = ""; //! Add api here!
-export const appName = "OneBusAway React WebApp"; //* customize here
 export const zoomRange = 0.01; //* customize here
-export const api_key = ""; //! Add key here!
-export const key_siri = ""; //! Add key here!
-export const api_key2 = ""; //! Add key here!
 export const zoomEnableSwitch = 14; //* customize here
 export const zoomForSelectedBusStation = 14; //* customize here
 export const zoomFullIcons = 10.5; //* customize here

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -22,13 +22,13 @@ import {
   SHOW_LIVE_BUSES,
   SHOW_SCHEDULED_BUSES,
 } from "./actionTypes";
-import { api_key, api_key2, key_siri, listPositionForAgency, prefixURL } from "./../config";
+import { apiKey, siriApiKey, listPositionForAgency, apiBaseURL } from "./../config";
 import { store } from "../redux/store";
 import { cutAgencyName, dynamicTexColor, getAcronym, removeDuplicateStops } from "../utils/helpers";
 
 export const fetchAgencyID = () => async (dispatch: Dispatch) => {
   await axios
-    .get(`${prefixURL}/api/where/agencies-with-coverage.json?key=${api_key}`)
+    .get(`${apiBaseURL}/api/where/agencies-with-coverage.json?key=${apiKey}`)
     .then(({ data }) => {
       // console.log("data:", data);
       const statusCode = data.code;
@@ -89,7 +89,7 @@ export const fetchAgencyID = () => async (dispatch: Dispatch) => {
 
 export const fetchLinesList = (agencyId: string) => async (dispatch: Dispatch) => {
   await axios
-    .get(`${prefixURL}/api/where/route-ids-for-agency/${agencyId}.json?key=${api_key}`)
+    .get(`${apiBaseURL}/api/where/route-ids-for-agency/${agencyId}.json?key=${apiKey}`)
     .then(({ data }) => {
       // console.log("data:", data.data);
       let unsortedList = data?.data?.list;
@@ -130,7 +130,7 @@ export const selectRoute = (routeNumber: number | string) => async (dispatch: Di
 export const fetchPolylines_Stops = (agencyId: string, routeNumber: string) => async (dispatch: Dispatch) => {
   // console.log({ agencyId, routeNumber });
   await axios
-    .get(`${prefixURL}/api/where/stops-for-route/${agencyId}_${routeNumber}.json?includePolylines=true&key=${api_key}`)
+    .get(`${apiBaseURL}/api/where/stops-for-route/${agencyId}_${routeNumber}.json?includePolylines=true&key=${apiKey}`)
     .then(({ data }) => {
       // console.log({ routeNumber });
       dispatch({ type: GET_POLYLINES_STOPS, payload: data.data });
@@ -146,7 +146,7 @@ export const fetchPolylines_Stops = (agencyId: string, routeNumber: string) => a
 export const getActiveBuses = (agencyId: string, routeNumber: number | string) => async (dispatch: Dispatch) => {
   // console.log({ agencyId, routeNumber });
   await axios
-    .get(`${prefixURL}/siri/vehicle-monitoring?key=${key_siri}&OperatorRef=${agencyId}&LineRef=${routeNumber}&type=json`)
+    .get(`${apiBaseURL}/siri/vehicle-monitoring?key=${siriApiKey}&OperatorRef=${agencyId}&LineRef=${routeNumber}&type=json`)
     .then(({ data }) => {
       // console.log("data:", data);
       const dataToFetch = data?.Siri?.ServiceDelivery?.VehicleMonitoringDelivery["0"].VehicleActivity;
@@ -163,7 +163,7 @@ export const getStopInfo = (stopId: string, time: string) => async (dispatch: Di
   const now = Date.now();
   // console.log({ now });
   await axios
-    .get(`${prefixURL}/api/where/arrivals-and-departures-for-stop/${stopId}.json?minutesAfter=${time}&key=${api_key}`)
+    .get(`${apiBaseURL}/api/where/arrivals-and-departures-for-stop/${stopId}.json?minutesAfter=${time}&key=${apiKey}`)
     .then(({ data }) => {
       const dataToFetch = data?.data?.entry?.arrivalsAndDepartures;
       const dataToSet = dataToFetch.sort(
@@ -187,7 +187,7 @@ export const getActiveBlocks = () => async (dispatch: Dispatch) => {
 
   await axios
     .get(
-      `${prefixURL}/api/where/trips-for-location.json?lat=${lat}&lon=${lon}&latSpan=${latSpan}&lonSpan=${lonSpan}&key=${api_key}`
+      `${apiBaseURL}/api/where/trips-for-location.json?lat=${lat}&lon=${lon}&latSpan=${latSpan}&lonSpan=${lonSpan}&key=${apiKey}`
     )
     .then(({ data }) => {
       // console.log("data:", data);
@@ -234,7 +234,7 @@ export const dispatchZoom = (zoom: number) => async (dispatch: Dispatch) => {
 export const getDirections = (agencyId: string, routeNumber: number | string) => async (dispatch: Dispatch) => {
   // console.log({ routeNumber });
   await axios
-    .get(`${prefixURL}/api/where/stops-for-route/${agencyId}_${routeNumber}.json?key=${api_key2}&type=JSON`)
+    .get(`${apiBaseURL}/api/where/stops-for-route/${agencyId}_${routeNumber}.json?key=${apiKey}&type=JSON`)
     .then(({ data }) => {
       const stopsWithInfo = data?.data?.references?.stops;
       const dataToDispatch = data?.data?.entry?.stopGroupings[0]?.stopGroups;
@@ -282,7 +282,7 @@ export const getAllPolylinesStops = () => async (dispatch: Dispatch) => {
     // console.log("list:", list);
     const endpoints = list?.list?.map(
       (routeNumber: number) =>
-        `${prefixURL}/api/where/stops-for-route/${agencyId}_${routeNumber}.json?includePolylines=true&key=${api_key}`
+        `${apiBaseURL}/api/where/stops-for-route/${agencyId}_${routeNumber}.json?includePolylines=true&key=${apiKey}`
     );
     // console.log("endpoints:", endpoints);
     const promises = endpoints.map((endpoint: string) => axios.get(endpoint));
@@ -371,7 +371,7 @@ export const getAllBuses = () => async (dispatch: Dispatch) => {
     // console.log("activeBlocks:", activeBlocks);
     const endpoints = activeBlocks?.activeBlocks?.map(
       (routeNumber: number) =>
-        `${prefixURL}/siri/vehicle-monitoring?key=${key_siri}&OperatorRef=${agencyId}&LineRef=${routeNumber}&type=json`
+        `${apiBaseURL}/siri/vehicle-monitoring?key=${siriApiKey}&OperatorRef=${agencyId}&LineRef=${routeNumber}&type=json`
     );
     // console.log("endpoints:", endpoints);
     const promises = endpoints.map((endpoint: string) => axios.get(endpoint));


### PR DESCRIPTION
* Remove `api_key2` - this seemed to be used identically to `api_key`, which was confusing to me.
* Rename `prefixURL` to `apiBaseURL` to clarify its purpose and expose through the `.env` file.
* Rename `api_key` to `apiKey` and expose through the `.env` file.
* Rename `key_siri` to `siriApiKey` and expose through the `.env` file.
* Add `.env` to the `.gitignore` so that users' API keys aren't unintentionally committed to the repository.
* Create an `example.env` file to show the list of available settings.
* Update README to reflect these changes.